### PR TITLE
Allow override of SMTP settings per site

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,21 @@ If you are run a dev environment without SSL, turn off secure cookies in .env
 ```
 COOKIE_SECURE_OFF=yes
 ```
+
+## Custom SMTP configuration per site
+If you want to configure the SMTP server through which e-mails are sent on a site-by-site basis, this is possible through configuration in the database.
+Under the `clients` table in the `config` column you can set the following parameters:
+
+```
+"smtpTransport": {
+    "host": "smtp.gmail.com",
+    "port": 465,
+    "secure": true,
+    "auth": {
+        "user": "username@gmail.com",
+        "pass": "password"
+    }
+}
+```
+
+Any configuration not provided will be fetched from the values set in the .env

--- a/controllers/auth/forgot.js
+++ b/controllers/auth/forgot.js
@@ -93,6 +93,8 @@
     */
    const sendEmail = (resetUrl, user, client) => {
      const clientConfig = client.config ? client.config : {};
+     const smtpTransportConfig = clientConfig.smtpTransport ? clientConfig.smtpTransport : {};
+     const transporterConfig = emailService.createTransporter(smtpTransportConfig);
 
      return emailService.send({
        toName: (user.firstName + ' ' + user.lastName).trim(),
@@ -106,7 +108,8 @@
          firstName: user.firstName,
          clientUrl: client.mainUrl,
          clientName: client.name,
-       }
+       },
+       transporterConfig
      });
    }
  }

--- a/controllers/auth/url.js
+++ b/controllers/auth/url.js
@@ -90,7 +90,8 @@ const sendEmail = (tokenUrl, user, client) => {
   const emailSubject = authTypeConfig.emailSubject ? authTypeConfig.emailSubject : 'Inloggen bij ' + client.name;
   const emailHeaderImage = authTypeConfig.emailHeaderImage ? authTypeConfig.emailHeaderImage : false;
   const emailLogo = authTypeConfig.emailLogo ? authTypeConfig.emailLogo : false;
-
+  const smtpTransportConfig = clientConfig.smtpTransport ? clientConfig.smtpTransport : {};
+  const transporterConfig = emailService.createTransporter(smtpTransportConfig);
 
   return emailService.send({
     toName: (user.firstName + ' ' + user.lastName).trim(),
@@ -107,7 +108,8 @@ const sendEmail = (tokenUrl, user, client) => {
       clientName: client.name,
       headerImage: emailHeaderImage,
       logo: emailLogo
-    }
+    },
+    transporterConfig
   });
 }
 

--- a/services/email.js
+++ b/services/email.js
@@ -8,7 +8,7 @@ const limitTo           = require('../nunjucks/limitTo');
 const jsonFilter        = require('../nunjucks/json');
 const timestampFilter   = require('../nunjucks/timestamp');
 
-exports.send = function ({subject, toName, toEmail, templateString, template, variables, fromEmail, fromName, replyTo}) {
+exports.send = function ({subject, toName, toEmail, templateString, template, variables, fromEmail, fromName, replyTo, transporterConfig}) {
 
   /**
    * Enrich variables with URLS in order to make absolute urls in E-mails
@@ -60,15 +60,7 @@ exports.send = function ({subject, toName, toEmail, templateString, template, va
   /**
    * Create instance of SMTP transporter
    */
-  const transporter = nodemailer.createTransport({
-      host: process.env.MAIL_SERVER_URL,
-      port: process.env.MAIL_SERVER_PORT,
-      secure: process.env.MAIL_SERVER_SECURE, // true for 465, false for other ports
-      auth: {
-        user: process.env.MAIL_SERVER_USER_NAME, // generated ethereal user
-        pass: process.env.MAIL_SERVER_PASSWORD // generated ethereal password
-      }
-  });
+  const transporter = nodemailer.createTransport(transporterConfig);
 
   return new Promise(function(resolve, reject) {
     // send mail with defined transport object
@@ -85,3 +77,15 @@ exports.send = function ({subject, toName, toEmail, templateString, template, va
     })
   });
 }
+
+exports.createTransporter = function ({ host, port, secure, auth }) {
+  return {
+    host:   host ? host : process.env.MAIL_SERVER_URL,
+    port:   port ? port : process.env.MAIL_SERVER_PORT,
+    secure: secure ? secure : process.env.MAIL_SERVER_SECURE,
+    auth:   {
+      user: (auth && auth.user) ? auth.user : process.env.MAIL_SERVER_USER_NAME,
+      pass: (auth && auth.pass) ? auth.pass : process.env.MAIL_SERVER_PASSWORD,
+    },
+  };
+};


### PR DESCRIPTION
This allows for the SMTP settings to be changed on a per-site basis through the config in the database. For some sites it should be possible to use a e-mail provider, depending on the kind of site.

Currently we are only supporting sending e-mail by SMTP, so if we change this support to include other methods of sending mail, we should also make this configuration more generic.

Related ticket: https://trello.com/c/7tEyehow/639-e-mails-vanuit-de-api-oauth-moeten-per-site-een-aanpasbare-mailserver-hebben