### PR TITLE
Admin login (Trello ticket 233)

### DIFF
--- a/controllers/auth/adminUrl.js
+++ b/controllers/auth/adminUrl.js
@@ -11,7 +11,7 @@ exports.postLogin = async (req, res, next) => {
     req.redirectUrl = clientConfig && clientConfig.emailRedirectUrl ? clientConfig.emailRedirectUrl : encodeURIComponent(req.query.redirect_uri);
 
     try {
-      req.user = await authService.validateUser(req.body.email);
+      req.user = await authService.validateUser(req.body.email,  req.client.id);
 
       await verificationService.sendVerification(req.user, req.client, req.redirectUrl);
 

--- a/controllers/auth/adminUrl.js
+++ b/controllers/auth/adminUrl.js
@@ -11,7 +11,7 @@ exports.postLogin = async (req, res, next) => {
     req.redirectUrl = clientConfig && clientConfig.emailRedirectUrl ? clientConfig.emailRedirectUrl : encodeURIComponent(req.query.redirect_uri);
 
     try {
-      req.user = await authService.validateUser(req.body.email,  req.client.id);
+      req.user = await authService.validatePrivilegeUser(req.body.email,  req.client.id);
 
       await verificationService.sendVerification(req.user, req.client, req.redirectUrl);
 

--- a/repositories/userRepository.js
+++ b/repositories/userRepository.js
@@ -1,0 +1,10 @@
+const User = require('../models/index').User;
+
+exports.getUserByClientAndRoles = (email, clientId, roles) => User
+    .query()
+    .join('user_roles', 'user_roles.userId', 'users.id')
+    .join('roles', 'roles.id', 'user_roles.roleId')
+    .where('users.email', '=', email)
+    .where('user_roles.clientId', '=', clientId)
+    .whereIn('roles.name', roles)
+    .first();

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,18 +1,10 @@
-const User = require('../models/index').User;
 const ActionLog = require('../models/index').ActionLog;
+const userRepository = require('../repositories/userRepository');
 const privilegedRoles =  require('../config/roles').privilegedRoles;
 
-exports.validateUser = async (email, clientId) => {
-
+exports.validatePrivilegeUser = async (email, clientId) => {
   // Get user for specific client and assigned to one of the privilegedRoles
-  const user = await User
-    .query()
-    .join('user_roles', 'user_roles.userId', 'users.id')
-    .join('roles', 'roles.id', 'user_roles.roleId')
-    .where('users.email', '=', email)
-    .where('user_roles.clientId', '=', clientId)
-    .whereIn('roles.name', privilegedRoles)
-    .first();
+  const user = await userRepository.getUserByClientAndRoles(email, clientId, privilegedRoles);
 
   if(!user) {
     throw new Error('User not found or user does not have the allowed roles');

--- a/test/unit/authService.js
+++ b/test/unit/authService.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('process').env.OAUTHRECIPES_SURPRESS_TRACE = true;
+
+const authService  = require('../../services/authService');
+const userRepository  = require('../../repositories/userRepository');
+
+jest.mock('../../repositories/userRepository');
+
+describe('AuthService', () => {
+
+  describe('validatePrivilegeUser', () => {
+    test('should throw an Error when user not found', async () => {
+      expect(authService.validatePrivilegeUser('some email', 'some client')).rejects.toEqual(new Error('User not found or user does not have the allowed roles'))
+    });
+
+    test('should return the user when user is valid', async () => {
+      userRepository.getUserByClientAndRoles.mockResolvedValue({
+        email: 'test@test.nl',
+        clientId: 1
+      });
+
+      expect(authService.validatePrivilegeUser('test@test.nl', '1')).resolves.toEqual({
+        email: 'test@test.nl',
+        clientId: 1
+      })
+    });
+  });
+});


### PR DESCRIPTION
Add check if the user have a privilegeRole for the given clientId.
See Trello ticket: https://trello.com/c/C9kpwftZ/233-admin-login-geef-foutmelding-bij-het-inloggen-als-een-gebruiker-g%C3%A9%C3%A9n-admin-is-voor-de-specifieke-site

Question: The admin panel is always linked to one oauth client? So only users with privilege roles for this client can access the admin panel?