### PR TITLE
Use client for title and logo href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 * Update NPM modules for security
+* Add client name to the page title, and client site URL to the logo href
 
 ## v0.8.0-PRERLEASE (2020-17-07)
 * Alter tables with foreign keys to user from delete restrict to delete cascade, meaning they automatically get deleted

--- a/views/elements/logo.html
+++ b/views/elements/logo.html
@@ -3,7 +3,7 @@
 {% if logo and logo === 'amsterdam-logo.html' %}
   {% include 'elements/amsterdam-logo.html' %}
 {% else %}
-<a class="{{'mainlogo' if logo === 'amsterdam-logo.html' else 'main-logo-container' }}" href="#">
+<a class="{{'mainlogo' if logo === 'amsterdam-logo.html' else 'main-logo-container' }}" href="{{ client.siteUrl }}" title="Terug naar {{ client.name }}">
   {% if logo %}
     <img id="logo-image" src="{{logo}}" />
   {% else %}

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Gemeente Amsterdam</title>
+  <title>{{ client.name }}</title>
   <!-- Needed for mobile sites to work -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="/css/main.css?v=1.1">


### PR DESCRIPTION
- Changes the site title to `client.name` to reflect the current site to the user.
- Adds a link back to the `client.siteUrl` on the logo and adds a text explaining this to the user.