### PR TITLE
Allow required field labels to be changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 * Update NPM modules for security
+* Allow labels of required fields to be changed through the client config
 
 ## v0.8.0-PRERLEASE (2020-17-07)
 * Alter tables with foreign keys to user from delete restrict to delete cascade, meaning they automatically get deleted

--- a/README.md
+++ b/README.md
@@ -110,3 +110,15 @@ Under the `clients` table in the `config` column you can set the following param
 ```
 
 Any configuration not provided will be fetched from the values set in the .env
+
+## Set custom labels for required fields
+
+By default the required fields have labels as defined in `config/user.js`. These labels can be overwritten in the `clients` table under the `config` column:
+
+```
+"requiredFields": {
+    "labels": {
+        "firstName": "Naam (alias)"
+    }
+}
+```

--- a/controllers/auth/required.js
+++ b/controllers/auth/required.js
@@ -12,7 +12,16 @@ exports.index = (req, res, next) => {
 
   const config = req.client.config ? req.client.config : {};
   const configRequiredFields = config && config.requiredFields ? config.requiredFields : {};
-
+  
+  // Replace field labels with labels defined in the client config (if provided)
+  if (configRequiredFields && configRequiredFields.labels) {
+    requiredUserFields = requiredUserFields.map((field) => {
+      if (configRequiredFields.labels[field.key]) {
+        field.label = configRequiredFields.labels[field.key];
+      }
+      return field;
+    });
+  }
 
   res.render('auth/required-fields', {
     client: req.client,

--- a/views/auth/required-fields.html
+++ b/views/auth/required-fields.html
@@ -29,7 +29,7 @@
             type="text"
             required
             name="{{requiredField.key}}"
-            class="input-{{requiredField}} input-field"
+            class="input-{{requiredField.key}} input-field"
           />
 				</div>
         {% endfor %}

--- a/views/auth/required-fields.html
+++ b/views/auth/required-fields.html
@@ -12,7 +12,7 @@
 			</h1>
 			<p>
 				{% if description %}
-					{{description}}
+					{{description | safe}}
 				{% else %}
 					Om verder te gaan hebben we nog wat extra gegevens nodig.
 				{% endif %}


### PR DESCRIPTION
- Allows the labels for required fields as defined in `config/user.js` to be overwritten by the client config.
- Allow HTML in the description of the required fields view
- Fix HTML class for required fields (was using the `requiredFields` object instead of the `requiredFields.key`)