### PR TITLE
Add an overwriteable default favicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 * Update NPM modules for security
+* Add a favicon that can be overwritten in the client config
 
 ## v0.8.0-PRERLEASE (2020-17-07)
 * Alter tables with foreign keys to user from delete restrict to delete cascade, meaning they automatically get deleted

--- a/README.md
+++ b/README.md
@@ -110,3 +110,7 @@ Under the `clients` table in the `config` column you can set the following param
 ```
 
 Any configuration not provided will be fetched from the values set in the .env
+
+## Favicon
+A default favicon can now be set through `DEFAULT_FAVICON` in the .env file.
+This default favicon can be overwritten by setting the `styling.favicon` in the `config` column in the `clients` table.

--- a/middleware/client.js
+++ b/middleware/client.js
@@ -48,6 +48,10 @@ exports.withOne = (req, res, next) => {
         if (clientConfigStyling && clientConfigStyling.logo) {
           res.locals.logo = clientConfigStyling.logo;
         }
+        
+        if (clientConfigStyling && clientConfigStyling.favicon) {
+          res.locals.favicon = clientConfigStyling.favicon;
+        }
 
         if (clientConfigStyling && clientConfigStyling.inlineCSS) {
           res.locals.inlineCSS = clientConfigStyling.inlineCSS;

--- a/routes.js
+++ b/routes.js
@@ -89,6 +89,10 @@ module.exports = function(app){
     if (process.env.LOGO) {
       res.locals.logo = process.env.LOGO;
     }
+    
+    if (process.env.DEFAULT_FAVICON) {
+    	res.locals.favicon = process.env.DEFAULT_FAVICON;
+		}
 
     next();
   });

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -18,6 +18,10 @@
   {% endfor %}
   {% endif %}
 
+  {% if favicon %}
+  <link rel="icon" href="{{ favicon }}">
+  {% endif %}
+
   {% if inlineCSS %}
   <style>{{inlineCSS}} </style>
   {% endif %}


### PR DESCRIPTION
The favicon can be set through `DEFAULT_FAVICON` in the .env file and can be overwritten in the client config through `styling.favicon`.