### PR TITLE
Keep login token valid after url request instead of invalidating them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 * Add phone number label
+* Don't invalid login token after making a new request, until login is successful, set to
 
 ## v0.14.2 (2020-05-26)
 * Change phone number format to +31 for sending SMS
@@ -21,7 +22,7 @@
 * In case password is not set create a random one when creating a user
 
 ## v0.11.0 (2020-01-27)
-* Fallback to roleId for member uniqueCode if none defaultRoleId isset
+* Fallback to roleId for member uniqueCode if none defaultRoleId is set
 * In case password is not set create a random one
 
 ## v0.10.0 (2020-12-09)
@@ -37,7 +38,7 @@
 * Alter tables with foreign keys to user from delete restrict to delete cascade, meaning they automatically get deleted
 
 ## 0.7.2 (2020-10-08)
-* Update openstad logo
+* Update Openstad logo
 
 ## 0.7.1 (2020-09-15)
 * Sender in email fell back to null null, Add check to make sure firstName / lastName exists in order to prevent casting null to string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## UNRELEASED
+* Add phone number label
+
 ## v0.14.2 (2020-05-26)
 * Change phone number format to +31 for sending SMS
 

--- a/services/verificationService.js
+++ b/services/verificationService.js
@@ -5,7 +5,14 @@ const tokenSMS = require('./tokenSMS');
 
 exports.sendVerification = async (user, client, redirectUrl, adminLoginRequest) => {
 
-  await tokenUrl.invalidateTokensForUser(user.id);
+  /**
+   * For now we don't invalidate tokens
+   * This causes a lot of UX issues with users.
+   * When they send double, email is late, the enter a loop of not being able to login.
+   * We keep the token shortlived and invalidate all after login
+   */
+//   await tokenUrl.invalidateTokensForUser(user.id);
+
   const generatedTokenUrl = await tokenUrl.format(client, user, redirectUrl, adminLoginRequest);
 
   const clientConfig = client.config ? client.config : {};

--- a/views/auth/url/authenticate.html
+++ b/views/auth/url/authenticate.html
@@ -13,7 +13,7 @@ Doing it with Javascript prevents the user from needing to do an extra click
 			<p class="intro">
 				Je kunt eenmalig inloggen met deze link.
 				De e-mail vanuit waar je deze link hebt geopend kun je hierna verwijderen.
-				Deze link is 60 minuten geldig.
+				Deze link is 30 minuten geldig.
 			</p>
 		</noscript>
 

--- a/views/emails/login-url.html
+++ b/views/emails/login-url.html
@@ -14,7 +14,7 @@ Voor {{clientName}}
 is een inloglink aangevraagd voor dit emailadres.
 Klik op de knop hieronder om automatisch in te loggen.
 <br />
-De knop is 60 minuten geldig.
+De knop is 30 minuten geldig.
 <br />
 <br />
 <p align="middle" style="margin: 10px 0;">


### PR DESCRIPTION
Currently a UX issue that if user requests a url to login and they ask again if arrives to late, the first version is invalid, then they receive first one, cant login, try again, and enter a login with wrong urls loop.