### PR TITLE
Add canCreateNewUsers check on login

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -83,7 +83,7 @@ passport.use('url', new TokenStrategy({
 passport.use('uniqueCode', new TokenStrategy({
   //   failRedirect : "/auth/code/login",
     varName : "unique_code"
-  }, function (code, done, client) { // put your check logic here
+}, function (code, done, client) { // put your check logic here
 
     new UniqueCode({
       code: code,
@@ -126,6 +126,7 @@ passport.use('uniqueCode', new TokenStrategy({
            * Client can ask for more information after registration
            * Not connected to existing users because of privacy reasons
            */
+          if (client.config && client.config.users && client.config.users.canCreateNewUsers === false) return done('Cannot create new users')
           new User({})
             .save()
             .then((newUser) => {

--- a/controllers/auth/anonymous.js
+++ b/controllers/auth/anonymous.js
@@ -28,7 +28,12 @@ exports.login  = (req, res, next) => {
 
 exports.register  = (req, res, next) => {
 
-	if (!req.session.createAnonymousUser) {
+  if (req.client && req.client.config.users && req.client.config.users && req.client.config.users.canCreateNewUsers === false) {
+		req.flash('error', {msg: 'Cannot create new users'});
+		return res.redirect(`/auth/anonymous/info?clientId=${req.client.clientId}&redirect_uri=${req.query.redirect_uri}`);
+  }
+
+  if (!req.session.createAnonymousUser) {
 
 		req.flash('error', {msg: 'Cookies zijn onmisbaar op deze site'});
 		return res.redirect(`/auth/anonymous/info?clientId=${req.client.clientId}&redirect_uri=${req.query.redirect_uri}`);

--- a/controllers/auth/phonenumber.js
+++ b/controllers/auth/phonenumber.js
@@ -99,7 +99,8 @@ exports.postLogin = async(req, res, next) => {
         user = await updateUser(user, phoneNumber);
       }
     } else {
-      user = await createUser(phoneNumber);
+      if (clientConfig.users && clientConfig.users.canCreateNewUsers === false) throw new Error('Cannot create new users');
+      user = await createUser(phoneNumber, clientConfig);
     }
     req.user = user.serialize();
 

--- a/controllers/auth/url.js
+++ b/controllers/auth/url.js
@@ -129,6 +129,7 @@ exports.postLogin = async (req, res, next) => {
             return handleSending(req, res, next);
         }
 
+        if (clientConfig.users && clientConfig.users.canCreateNewUsers === false) throw new Error('Cannot create new users');
         user = await createUser(req.body.email);
 
         req.user = user.serialize();


### PR DESCRIPTION
The API has a config field users.canCretaeNewUsers. When this field is set to false the route to create users is closed. Administrators can no longer create users.

But ordinary visitors _can_ create users by simply logging in. This update fixes that.
