### PR TITLE
Set the emailUrlBruteForce to be very restricted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Unreleased
+* Make the email url brute force more restrictive
 
 ## v0.16.0 (2020-07-20)
 * Add external CSRF token

--- a/middleware/client.js
+++ b/middleware/client.js
@@ -6,6 +6,7 @@ const authTypes = require('../config/auth').types;
 const privilegedRoles =  require('../config/roles').privilegedRoles;
 const authTypesConfig = require('../config').authTypes
 const defaultRole =  require('../config/roles').defaultRole;
+const getClientIdFromRequest = require('../utils/getClientIdFromRequest');
 
 exports.withAll = (req, res, next) => {
   Client
@@ -19,7 +20,7 @@ exports.withAll = (req, res, next) => {
 }
 
 exports.withOne = (req, res, next) => {
-  let clientId = req.body && req.body.clientId ? req.body.clientId : req.query.clientId;
+  const clientId = getClientIdFromRequest(req);
   
   if (!clientId) {
     clientId = req.query.client_id;

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -26,6 +26,7 @@ const authMw = require('../middleware/auth');
 const passwordResetMw = require('../middleware/passwordReset');
 const logMw = require('../middleware/log');
 
+//UTILS
 const getClientIdFromRequest = require('../utils/getClientIdFromRequest');
 
 //MODELS
@@ -65,10 +66,10 @@ const emailUrlBruteForce = bruteForce.userVeryRestricted.getMiddleware({
         const clientId = getClientIdFromRequest(req);
         
         if (clientId) {
-            next(`${clientId}-${req.body.email}`);
-        } else {
-            next(`${req.body.email}`);
+            return next(`${clientId}-${req.body.email}`);
         }
+        
+        return next(`${req.body.email}`);
     }
 });
 

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -26,6 +26,8 @@ const authMw = require('../middleware/auth');
 const passwordResetMw = require('../middleware/passwordReset');
 const logMw = require('../middleware/log');
 
+const getClientIdFromRequest = require('../utils/getClientIdFromRequest');
+
 //MODELS
 const ExternalCsrfToken = require('../models').ExternalCsrfToken;
 
@@ -57,10 +59,16 @@ const smsCodeBruteForce = bruteForce.user.getMiddleware({
     }
 });
 
-const emailUrlBruteForce = bruteForce.user.getMiddleware({
+// prevent too many attempts for the same email per clientId (if applicable)
+const emailUrlBruteForce = bruteForce.userVeryRestricted.getMiddleware({
     key: function (req, res, next) {
-        // prevent too many attempts for the same email
-        next(req.body.email);
+        const clientId = getClientIdFromRequest(req);
+        
+        if (clientId) {
+            next(`${clientId}-${req.body.email}`);
+        } else {
+            next(`${req.body.email}`);
+        }
     }
 });
 

--- a/utils/getClientIdFromRequest.js
+++ b/utils/getClientIdFromRequest.js
@@ -1,0 +1,24 @@
+/**
+ * Get the correct clientId from the passed request
+ *
+ * @param req
+ * @returns {boolean|*}
+ */
+module.exports = (req) => {
+  
+  if (!req) {
+    return false;
+  }
+  
+  let clientId = req.body && req.body.clientId ? req.body.clientId : req.query.clientId;
+  
+  if (!clientId) {
+      clientId = req.query.client_id;
+  }
+
+  if (!clientId) {
+      clientId = req.params.clientId;
+  }
+  
+  return clientId;
+}

--- a/utils/getClientIdFromRequest.js
+++ b/utils/getClientIdFromRequest.js
@@ -10,13 +10,17 @@ module.exports = (req) => {
     return false;
   }
   
-  let clientId = req.body && req.body.clientId ? req.body.clientId : req.query.clientId;
+  let clientId = req.body && req.body.clientId;
   
-  if (!clientId) {
+  if (!clientId && req.query && req.query.clientId) {
+    clientId = req.query.clientId;
+  }
+  
+  if (!clientId && req.query && req.query.client_id) {
       clientId = req.query.client_id;
   }
 
-  if (!clientId) {
+  if (!clientId && req.params && req.params.clientId) {
       clientId = req.params.clientId;
   }
   


### PR DESCRIPTION
Previously, it was possible to spam an e-mail through the URL login by repeated submission of the login form.

This commit changes the bruteforce protection for the email URL brute force to the very restricted version, only allowing 5 free retries. The key for this bruteforce now includes the clientId, to ensure the user can log in to multiple sites in succession without errors.

The code to retrieve the clientId has been refactored from client middleware the into its' own util function, to prevent duplication.