### PR TITLE
Redirect on ean error in deserialize user

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -263,6 +263,9 @@ passport.deserializeUser((id, done) => {
   User
     .where({id: id})
     .fetch()
-    .then(user => done(null, user.serialize()))
+    .then(user => {
+      if (!user) throw new Error('Error in deserializeUser for id='+id);
+      done(null, user.serialize())
+    })
     .catch(err => done(err));
 });

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -332,12 +332,13 @@ module.exports = function (app) {
           console.log(err); // do log for debugging
           await req.session.destroy();
           let querystring = '?'
-          if (req.query.clientId) querystring += req.query.clientId;
-          if (req.query.client_id) querystring += req.query.client_id;
-          if (req.query.redirectUrl) querystring += encodeURIComponent(req.query.redirect_uri);
-          if (req.query.token) querystring += req.query.token;
-          if (req.query.access_token) querystring += req.query.access_token;
-          return res.redirect('/login'+querystring);
+          if (req.query.clientId) querystring += `&clientId=${req.query.clientId}`;
+          if (req.query.client_id) querystring += `&client_id=${req.query.client_id}`;
+          if (req.query.redirectUrl) querystring += `&redirectUrl=${encodeURIComponent(req.query.redirectUrl)}`;
+          if (req.query.redirect_uri) querystring += `&redirect_uri=${encodeURIComponent(req.query.redirect_uri)}`;
+          if (req.query.token) querystring += `&token=${req.query.token}`;
+          if (req.query.access_token) querystring += `&access_token=${req.query.access_token}`;
+          return res.redirect('/logout'+querystring);
         }
         res.status(500).render('errors/500');
     });

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -325,8 +325,21 @@ module.exports = function (app) {
     });
 
     // Handle 500
-    app.use(function (err, req, res, next) {
+    app.use(async function (err, req, res, next) {
         console.log('===> err', err);
+        // een deserialize error betekent een data fout; daar hoef je een gebruiker niet mee te belasten
+        if (err && err.message && err.message.match(/^Error in deserializeUser/)) {
+          console.log(err); // do log for debugging
+          await req.session.destroy();
+          let querystring = '?'
+          if (req.query.clientId) querystring += req.query.clientId;
+          if (req.query.client_id) querystring += req.query.client_id;
+          if (req.query.redirectUrl) querystring += encodeURIComponent(req.query.redirect_uri);
+          if (req.query.token) querystring += req.query.token;
+          if (req.query.access_token) querystring += req.query.access_token;
+          return res.redirect('/login'+querystring);
+        }
         res.status(500).render('errors/500');
     });
+
 }


### PR DESCRIPTION
When deserializing a user that is not found in the database, do not throw an error but redirect to the login page.