### PR TITLE
Allow MongoDB credentials to be set

### DIFF
--- a/app-init.js
+++ b/app-init.js
@@ -40,6 +40,11 @@ const sessionStore = new MySQLStore({
 
 
 function getMongoDbConnectionString () {
+  // Allow the connection string builder to be overridden by an environment variable
+  if (process.env.MONGO_DB_CONNECTION_STRING) {
+    return process.env.MONGO_DB_CONNECTION_STRING;
+  }
+  
   const host = process.env.MONGO_DB_HOST || 'localhost';
   const port = process.env.MONGO_DB_PORT || 27017;
   const user = process.env.MONGO_DB_USER || '';

--- a/app-init.js
+++ b/app-init.js
@@ -39,12 +39,19 @@ const sessionStore = new MySQLStore({
 */
 
 
-const mongoCredentials = {
-  host: process.env.MONGO_DB_HOST || 'localhost',
-  port: process.env.MONGO_DB_PORT || 27017,
+function getMongoDbConnectionString () {
+  const host = process.env.MONGO_DB_HOST || 'localhost';
+  const port = process.env.MONGO_DB_PORT || 27017;
+  const user = process.env.MONGO_DB_USER || '';
+  const password = process.env.MONGO_DB_PASSWORD || '';
+  const authSource = process.env.MONGO_DB_AUTHSOURCE || '';
+  
+  const useAuth = user && password;
+  
+  return `mongodb://${useAuth ? `${user}:${password}@` : ''}${host}:${port}/sessions${authSource ? `?authSource=${authSource}` : ''}`;
 }
 
-const url = 'mongodb://'+ mongoCredentials.host +':'+mongoCredentials.port+'/sessions';
+const url = getMongoDbConnectionString();
 
 const sessionStore =  new MongoStore({
     url: url,


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description

This commit together with https://github.com/openstad/openstad-frontend/pull/354 allows MongoDB to have authentication.

This commit introduces 3 new environment variables:
- MONGO_DB_USER
- MONGO_DB_PASSWORD
- MONGO_DB_AUTHSOURCE

If both `MONGO_DB_USER` and `MONGO_DB_PASSWORD` are set, they are added to the MongoDB connection string.
The `MONGO_DB_AUTHSOURCE` allows us to specify which database we are authenticating against. (see https://www.mongodb.com/docs/manual/reference/connection-string/#std-label-connections-connection-options)

## Issue reference

No issue was made for this yet due to time constraints

## Type of change

New feature

## Documentation

Will be added to the `openstad-kubernetes` docs in the corresponding PR

## Tests

Locally

## Branch

-

