### PR TITLE
Add `MYSQL_CA_CERT` for MySQL SSL connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## UNRELEASED
+* Allow connecting to MySQL through SSL by providing a CA certificate
+
 ## v0.40.0
 Update version number
 

--- a/README.md
+++ b/README.md
@@ -125,3 +125,6 @@ By default the required fields have labels as defined in `config/user.js`. These
     }
 }
 ```
+
+## MySQL with SSL
+When you want to connect to a MySQL server using SSL, a Certificate Authority certificate is required. The contents of this CA certificate can be passed into the `MYSQL_CA_CERT` environment variable.

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,15 +1,24 @@
 // Update with your config settings.
 require('dotenv').config();
 
+const connection = {
+  host:     process.env.DB_HOST,
+  database: process.env.DB_NAME,
+  user:     process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+};
+
+if (process.env.MYSQL_CA_CERT) {
+	connection.ssl = {
+		rejectUnauthorized: true,
+		ca: [ process.env.MYSQL_CA_CERT ]
+	}
+}
+
 module.exports = {
   development: {
     client: 'mysql',
-    connection: {
-      host:     process.env.DB_HOST,
-      database: process.env.DB_NAME,
-      user:     process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-    },
+    connection,
     migrations: {
       directory: __dirname + '/knex/migrations',
     },
@@ -31,12 +40,7 @@ module.exports = {
 
   production: {
     client: 'mysql',
-    connection: {
-      host:     process.env.DB_HOST,
-      database: process.env.DB_NAME,
-      user:     process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-    },
+    connection,
     migrations: {
       directory: __dirname + '/knex/migrations',
     },


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description

Currently it's not possible to connect to a MySQL server through SSL. This PR adds a `MYSQL_CA_CERT` environment variable which allows us to add a CA (Certificate Authority) certificate. When this certificate is provided, it is added to the MySQL connection options, and invalid SSL handshakes / certificates are rejected.

Related PRs have been made in the api, image & kubernetes repositories: 

https://github.com/openstad/openstad-api/pull/241
https://github.com/openstad/openstad-image-server/pull/35
https://github.com/openstad/openstad-kubernetes/pull/78

## Issue reference



## Type of change

New feature through an environment variable. Keeps backwards compatibility.

## Documentation

See README.md

## Tests

Locally

## Branch
