### PR TITLE
fetch the userroles with belonging to the client on given parameters

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -10,6 +10,11 @@ const Client = bookshelf.Model.extend({
   requireFetch: false,
   hasTimestamps: ['createdAt', 'updatedAt'],
   jsonColumns: ['authTypes', 'requiredFields'],
+  userRoles: function () {
+    return this.hasMany(UserRole, 'clientId').query(function(builder) {
+      builder.columns("clientId", "userId", "roleId");
+    });
+  },
   getAuthTypes: (model) => {
     const authTypes = JSON.parse(model.get('authTypes'));
     
@@ -38,16 +43,16 @@ const UniqueCode = bookshelf.Model.extend({
   hasTimestamps: ['createdAt', 'updatedAt']
 });
 
-const Role = bookshelf.Model.extend({
-  tableName: 'roles',
-  requireFetch: false,
-  hasTimestamps: ['createdAt', 'updatedAt']
-});
-
 const UserRole = bookshelf.Model.extend({
   tableName: 'user_roles',
   requireFetch: false,
-  hasTimestamps: ['createdAt', 'updatedAt']
+  hasTimestamps: ['createdAt', 'updatedAt'],
+});
+
+const Role = bookshelf.Model.extend({
+  tableName: 'roles',
+  requireFetch: false,
+  hasTimestamps: ['createdAt', 'updatedAt'],
 });
 
 const PasswordResetToken = bookshelf.Model.extend({
@@ -63,7 +68,7 @@ const User = bookshelf.Model.extend({
   requireFetch: false,
   hasTimestamps: ['createdAt', 'updatedAt'],
   // jsonColumns: ['extraData'],
-  roles() {
+  roles: function () {
     return this.belongsToMany(Role, 'user_roles', 'userId', 'roleId');
   },
   format(attributes) {


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description
Is needed by pr https://github.com/openstad/openstad-management-panel/pull/68
Added the {withRelated userRoles} to the client.js, making it possible to fetch all userroles that belong to the given client.
Userroles can be filtered by using the given params ?withUserRoles=1&excludingRoles=admin,member,etc

Please include
- Added the {withRelated userRoles} to the client.js
- Added relation userRoles to the client bookshelf model in auth/models/index.js.

## Type of change
Feature

## Documentation
Userroles can be filtered by using the given params ?withUserRoles=1&excludingRoles=admin,member,etc

Is the documentation updated, maybe a link

## Tests
Tested using insomnia on route /api/admin/client/{a client id}?withUserRoles=1&excludingRoles=admin
