### PR TITLE
hotfix: set redirecturl to null when unparseable

### DIFF
--- a/controllers/auth/local.js
+++ b/controllers/auth/local.js
@@ -132,7 +132,7 @@ exports.logout = async (req, res) => {
     const redirectUrlHost = redirectURL ? new URL(redirectURL).hostname : false;
     redirectURL           = redirectUrlHost && allowedDomains && allowedDomains.indexOf(redirectUrlHost) !== -1 ? redirectURL : false;
   } catch (e) {
-    //
+    redirectURL = null;
   }
 
   if (!redirectURL) {


### PR DESCRIPTION
When given redirect url is unparseable e.g. `//openstad.org` the redirectURL wasn't reset so the given redirectURL became allowed. This resets the redirecturl when parsing fails